### PR TITLE
Change post time from 0800 to 0100 for ease of use across time zones

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,9 +17,9 @@ client.once("ready", () => {
     ?.toString() as string;
 
   /**
-   * This will run every day at 0800.
+   * This will run every day at 0100.
    */
-  schedule("0 8 * * *", () => {
+  schedule("0 1 * * *", () => {
     (async () => {
       const {
         activeDailyCodingChallengeQuestion: {


### PR DESCRIPTION
Quick and dirty update: old 0800 -> new 0100.
Wasn't sure of reliability for fetching new dailies right around 0000, so I've given the leetcode servers a comfortable hour to get things in order.